### PR TITLE
Exclude terminated instances when selecting first node

### DIFF
--- a/tools/join_riak_cluster.py
+++ b/tools/join_riak_cluster.py
@@ -27,7 +27,7 @@ def get_group_info(ec2conn, instance_id) :
 def get_autoscale_info(ec2conn, instance) :
     autoscale_group = instance.tags['aws:autoscaling:groupName']
     private_ip = instance.private_ip_address
-    filters = {'tag:aws:autoscaling:groupName': '%s*' % autoscale_group }
+    filters = {'tag:aws:autoscaling:groupName': '%s*' % autoscale_group, 'instance-state-name': 'running'}
     reservations = ec2conn.get_all_instances(filters=filters)
     instances = [i for r in reservations for i in r.instances]
     sorted_instances = sorted(instances, key=lambda i: (i.launch_time, i.id))


### PR DESCRIPTION
The join_riak_cluster.py script runs correctly in a clean VPC as part of the Cloud Formation script. However, if the first Riak node (as selected by launch time) dies or is terminated and a new instance is launched, the script will try to use the IP of the terminated instance rather than the next "first" instance. This patch further restricts the filter to running instances within the autoscale group.
